### PR TITLE
fixes minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ Every file created inside must have well defined documentation section in the st
 This project has recieved major contribution of;
 * [Khemraj Shrestha](https://github.com/itsmekhemraj) \(THA077BCT020\)
 * [Niyoj Oli](https://github.com/niyoj) \(THA077BCT029\)
-* [Om Prakash Sharma](https://github/com/ompiepy) \(THA077BCT030\)
+* [Om Prakash Sharma](https://github.com/ompiepy) \(THA077BCT030\)
 * Punam Shrestha \(THA077BCT038\)


### PR DESCRIPTION
## Changes Done in this PR
- There was a typo in the line number 42 of the README.md file which resulted the link to be `https://github/com/ompiepy` instead of `https://github.com/ompiepy`
- The change was done and the broken link was fixed.